### PR TITLE
Option not to return document text in search results

### DIFF
--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -72,7 +72,7 @@ module OpenAI
       )
     end
 
-    def search(documents:, query:, engine: default_engine)
+    def search(documents:, query:, engine: default_engine, return_text: true)
       body = {
         "documents" => documents,
         "query"     => query,
@@ -80,9 +80,9 @@ module OpenAI
 
       search_results = post("/v1/engines/#{engine}/search", body: body)
       search_results[:data].map.with_index do |datum, index|
-        SearchResult.new(**datum).tap do |result|
-          result.text = documents[index]
-        end
+        result = SearchResult.new(**datum)
+        result.text = documents[index] if return_text
+        result
       end
     end
 

--- a/spec/openai/client_spec.rb
+++ b/spec/openai/client_spec.rb
@@ -111,15 +111,25 @@ RSpec.describe OpenAI::Client do
         .to_return(body: File.read("spec/fixtures/search.json"), headers: response_headers)
     end
 
+    let(:documents) { ["White House", "hospital", "school"] }
+    let(:query) { "the president" }
+    let(:search_params) { { documents: documents, query: query, engine: "ada" } }
+
     it "searches" do
-      documents = ["White House", "hospital", "school"]
-      query = "the president"
-      results = client.search(documents: documents, query: query, engine: "ada")
+      results = client.search(search_params)
       expect(results).to be_an(Array)
       first_result = results.first
       expect(first_result.document).to eq(0)
       expect(first_result.score).to be_a(Float)
       expect(first_result.score).to be >= 0.0
+      expect(first_result.text).to eq(documents[first_result.document])
+    end
+
+    context "with return_text false" do
+      it "searches but doesn't return document text" do
+        results = client.search(search_params.merge(return_text: false))
+        expect(results.map(&:text)).to all(be_nil)
+      end
     end
   end
 end


### PR DESCRIPTION
When working with long lists of larger documents, it can be cumbersome to initialize `SearchResult` structs containing all of the document text. Moreover, in cases where the search documents are constructed to represent larger pieces of content, the document text is not useful; only the document index is. 

I would actually prefer the `return_text` to default to false to match the actual response returned from OpenAI. However, I didn't want to introduce a breaking change, so I took this approach.